### PR TITLE
Stop label spam.

### DIFF
--- a/lib/label.js
+++ b/lib/label.js
@@ -147,9 +147,25 @@ function getLabelsFromFiles(files) {
 
 exports.setLabels = setLabels;
 function setLabels(issue, labels) {
-    return github.post('/repos/:owner/:repo/issues/:number/labels', labels, { number: issue }).then(function(labels) {
-        return labels.map(funk.prop('name'));
+    return getLabels(issue).then(function(existingLabels) {
+        return findExtraLabels(existingLabels, labels);
+    }).then(function(labels) {
+        if (!labels.length) { return labels; }
+        return github.post('/repos/:owner/:repo/issues/:number/labels', labels, { number: issue }).then(function(labels) {
+            return labels.map(funk.prop('name'));
+        });
     });
+}
+
+exports.findExtraLabels = findExtraLabels;
+function findExtraLabels(existingLabels, newLabels) {
+    var output = [];
+    newLabels.forEach(function(label) {
+        if (existingLabels.indexOf(label) < 0) {
+            output.push(label);
+        }
+    });
+    return output;
 }
 
 exports.getLabels = getLabels;

--- a/test/labels.js
+++ b/test/labels.js
@@ -24,4 +24,10 @@ suite('Test github labels abstraction', function() {
     test('getLabelsFromFiles must return "infra" for content identified as such', function() {
         assert.equal("infra", label.getLabelsFromFiles([{filename: ".gitignore"}])[0]);
     });
+    
+    test('findExtraLabels returns the newly added labels only', function() {
+        assert.deepEqual(["foo", "bar"], label.findExtraLabels(["baz"], ["foo", "bar", "baz"]));
+        assert.deepEqual([], label.findExtraLabels(["baz"], ["baz"]));
+        assert.deepEqual([], label.findExtraLabels(["baz"], []));
+    });
 });


### PR DESCRIPTION
Work around GitHub logging, to the commit timeline, every time pull request labels are touched through the API, _even when no changes are made_.
