### PR TITLE
Adding reviewer exemption for some WebKit exports

### DIFF
--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -83,10 +83,11 @@ module.exports = function getMetadada(number, author, content) {
             // The above is missing the case where a reviewer which has write permission and is not an owner was added.
             metadata.reviewedDownstream = (metadata.author.login == "chromium-wpt-export-bot") ||
                 (metadata.author.login == "servo-wpt-sync") ||
+                ((metadata.author.login == "fwang" || metadata.author.login == "rniwa" || metadata.author.login == "youennf") && content.indexOf("WebKit export") > -1) ||
                 (metadata.author.login == "jgraham" && content.indexOf("MozReview-Commit-ID") > -1);
-            
+
             metadata.missingReviewers = getReviewers(metadata);
-            
+
             return metadata;
-        });        
+        });
 };


### PR DESCRIPTION
See https://github.com/w3c/web-platform-tests/pull/8986 for some background.
Starting with @fwang @rniwa and myself for downstream reviews of WPT PRs.
CCing @foolip as well.

Not exactly sure whether WebKit export script puts "WebKit export" inside "content" (PR title starts with WebKit export). It should be fairly easy anyway to adapt WebKit export script if need be.