### PR TITLE
Don't react to PR comments

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -9,6 +9,10 @@ function filterEvent(body, log) {
         log("Ignoring event: no body");
         return false;
     }
+    if (!body.pull_request) {
+        log("Ignoring event: not a pull request");
+        return false;
+    }
     if (body.sender && body.sender.login == "wpt-pr-bot") {
         log("Ignoring event: sender is wpt-pr-bot");
         return false;

--- a/test/filter.js
+++ b/test/filter.js
@@ -12,10 +12,14 @@ suite('Event filtering', function() {
         assert.strictEqual(filter.event(null, nullLog), false);
     });
     test('empty body', function() {
-        assert.strictEqual(filter.event({}, nullLog), true);
+        assert.strictEqual(filter.event({}, nullLog), false);
+    });
+    test('pull request', function() {
+        assert.strictEqual(filter.event({pull_request: {}}, nullLog), true);
     });
     test('wpt-pr-bot sender', function() {
         assert.strictEqual(filter.event({
+            pull_request: {},
             sender: {
                 login: 'wpt-pr-bot'
             }
@@ -23,6 +27,7 @@ suite('Event filtering', function() {
     });
     test('other sender', function() {
         assert.strictEqual(filter.event({
+            pull_request: {},
             sender: {
                 login: 'some-other-user'
             }


### PR DESCRIPTION
This simplifies the filtering and removes the need to fetch the pull
request in `getPullRequest`.